### PR TITLE
Add some CI validation of YAML configs

### DIFF
--- a/.github/workflows/config-test/Dockerfile
+++ b/.github/workflows/config-test/Dockerfile
@@ -1,0 +1,9 @@
+FROM alpine
+
+RUN apk add --no-cache yamllint bash
+
+WORKDIR /app/
+
+COPY test_all_configs.sh /usr/local/bin/test_all_configs.sh
+
+CMD /usr/local/bin/test_all_configs.sh 

--- a/.github/workflows/config-test/Dockerfile
+++ b/.github/workflows/config-test/Dockerfile
@@ -1,9 +1,7 @@
-FROM alpine
+FROM python:3.9-alpine
 
-RUN apk add --no-cache yamllint bash
+RUN pip3 install pyyaml
 
-WORKDIR /app/
+COPY test_all_configs.py /usr/local/bin/test_all_configs.py
 
-COPY test_all_configs.sh /usr/local/bin/test_all_configs.sh
-
-CMD /usr/local/bin/test_all_configs.sh 
+CMD /usr/local/bin/test_all_configs.py

--- a/.github/workflows/config-test/test_all_configs.py
+++ b/.github/workflows/config-test/test_all_configs.py
@@ -1,0 +1,53 @@
+#!/usr/local/bin/python
+
+import os
+import yaml
+from datetime import date
+
+# set directory of config files as variable
+directory = '/configs/'
+
+# little function for validating a vendor record
+def validate_vendor(vendor):
+    # validate name attribute
+    # confirm attribute exists
+    if "name" not in vendor:
+        raise Exception('No "name" attribute for vendor!')
+    # confirm value exists and isn't empty space
+    if not vendor["name"] or vendor["name"].isspace():
+        raise Exception('"name" attribute for vendor is blank!')
+
+    # validate url attribute
+    # confirm attribute exists
+    if "vendor_url" not in vendor:
+        raise Exception(f'No "vendor_url" attribute for {vendor["name"]}!')
+    # confirm value exists and isn't empty space
+    if not vendor["vendor_url"] or vendor["vendor_url"].isspace():
+        raise Exception(f'"vendor_url" for {vendor["name"]} is blank!')
+
+    # validate update_at attribute
+    # confirm attribute exists
+    if "updated_at" not in vendor:
+        raise Exception(f'No "updated_at" attribute for {vendor["name"]}!')
+    # confirm value exists and is a date
+    if not vendor["updated_at"] or not isinstance(vendor["updated_at"], date):
+        raise Exception(f'"updated_at" for {vendor["name"]} is not a date!')
+
+    # validate attributes that don't require a value
+    if not all(required_attribute in vendor for required_attribute in ("ios_app","android_app", "windows_client", "mac_client", "linux_client", "test_results")):
+        raise Exception(f"You seem to have removed an attribute from the template YAML file. All attributes are required, even if a value is not required.")
+    # report success
+    print(f'Configuration for {vendor["name"]} looks valid!')
+
+# iterate over all files in config directory
+for filename in os.listdir(directory):
+    full_path = os.path.join(directory, filename)
+    # check if it's a file
+    if os.path.isfile(full_path):
+        with open(full_path, 'r') as file:
+            vendor = yaml.safe_load(file)
+            try:
+                validate_vendor(vendor)
+            except Exception as exception:
+                print(f"Problem with {filename}: {exception}")
+                raise

--- a/.github/workflows/config-test/test_all_configs.sh
+++ b/.github/workflows/config-test/test_all_configs.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-set -e
-
-for filename in /configs/; do
-    yamllint -d relaxed ${filename}
-done

--- a/.github/workflows/config-test/test_all_configs.sh
+++ b/.github/workflows/config-test/test_all_configs.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+for filename in /configs/; do
+    yamllint -d relaxed ${filename}
+done

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,3 +17,11 @@ jobs:
         run: |
           until docker inspect --format "{{json .State.Health.Status }}" webauthn-hall-of-shame-local-dev | \
           grep -m 1 '"healthy"'; do sleep 5; done;
+  
+  yaml-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo content
+        uses: actions/checkout@v2
+      - name: Run YAML linter on all configs
+        run: make yaml-lint

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,10 +18,10 @@ jobs:
           until docker inspect --format "{{json .State.Health.Status }}" webauthn-hall-of-shame-local-dev | \
           grep -m 1 '"healthy"'; do sleep 5; done;
   
-  yaml-lint:
+  test-configs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo content
         uses: actions/checkout@v2
       - name: Run YAML linter on all configs
-        run: make yaml-lint
+        run: make test-configs

--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,8 @@ update-gemfile:
 	docker run -it --rm --workdir=/app/ --entrypoint=/app/update_gemfile.sh \
 		--mount type=bind,source=${CURDIR},destination=/app/ ${IMAGE}
 
-#yaml-lint: @ Run YAML Linter on each config
-yaml-lint:
+#test-configs: @ Test parseability and validity of each config
+test-configs:
 	docker build -t webauthn-hall-of-shame-config-test .github/workflows/config-test/
 	docker run --rm --mount type=bind,source=${CURDIR}/_vendors,destination=/configs/ webauthn-hall-of-shame-config-test 
 

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,11 @@ update-gemfile:
 	docker run -it --rm --workdir=/app/ --entrypoint=/app/update_gemfile.sh \
 		--mount type=bind,source=${CURDIR},destination=/app/ ${IMAGE}
 
+#test-all-configs: @ Test the YAML config for each vendor
+test-all-configs:
+	docker build -t webauthn-hall-of-shame-config-test .github/workflows/config-test/
+	docker run --rm --mount type=bind,source=${CURDIR}/_vendors,destination=/configs/ webauthn-hall-of-shame-config-test 
+
 #stop: @ Stop the container
 stop:
 	@docker stop webauthn-hall-of-shame-local-dev || true

--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,8 @@ update-gemfile:
 	docker run -it --rm --workdir=/app/ --entrypoint=/app/update_gemfile.sh \
 		--mount type=bind,source=${CURDIR},destination=/app/ ${IMAGE}
 
-#test-all-configs: @ Test the YAML config for each vendor
-test-all-configs:
+#yaml-lint: @ Run YAML Linter on each config
+yaml-lint:
 	docker build -t webauthn-hall-of-shame-config-test .github/workflows/config-test/
 	docker run --rm --mount type=bind,source=${CURDIR}/_vendors,destination=/configs/ webauthn-hall-of-shame-config-test 
 

--- a/_vendors/adobe.yaml
+++ b/_vendors/adobe.yaml
@@ -1,10 +1,10 @@
 ---
 name: Adobe Enterprise
-ios_app: 
-android_app: 
+ios_app:
+android_app:
 windows_client: unclear
-mac_client: 
-linux_client: 
-test_results: 
+mac_client:
+linux_client:
+test_results:
 updated_at: 2022-11-08
 vendor_url: https://www.adobe.com/enterprise.html

--- a/_vendors/amazonchime.yaml
+++ b/_vendors/amazonchime.yaml
@@ -1,10 +1,10 @@
 ---
 name: Amazon Chime
 ios_app: webview
-android_app: 
-windows_client: 
+android_app:
+windows_client:
 mac_client: webview
-linux_client: 
-test_results: 
+linux_client:
+test_results:
 updated_at: 2022-11-09
 vendor_url: https://aws.amazon.com/chime/

--- a/_vendors/azurevirtualdesktop.yaml
+++ b/_vendors/azurevirtualdesktop.yaml
@@ -1,10 +1,10 @@
 ---
 name: Azure Virtual Desktop
-ios_app: 
-android_app: 
-windows_client: 
+ios_app:
+android_app:
+windows_client:
 mac_client: unclear
-linux_client: 
-test_results: 
+linux_client:
+test_results:
 updated_at: 2022-11-08
 vendor_url: https://learn.microsoft.com/en-us/azure/virtual-desktop/users/connect-macos

--- a/_vendors/ciscoanyconnect.yaml
+++ b/_vendors/ciscoanyconnect.yaml
@@ -1,10 +1,10 @@
 ---
 name: Cisco AnyConnect
-ios_app: 
-android_app: 
+ios_app:
+android_app:
 windows_client: true
 mac_client: false
-linux_client: 
-test_results: 
+linux_client:
+test_results:
 updated_at: 2023-09-06
 vendor_url: https://www.cisco.com/c/en/us/support/security/anyconnect-secure-mobility-client-v4-x/model.html

--- a/_vendors/globalprotect.yaml
+++ b/_vendors/globalprotect.yaml
@@ -1,10 +1,10 @@
 ---
-name: GlobalProtect 
+name: GlobalProtect
 ios_app: true
 android_app: webview
 windows_client: true
 mac_client: true
-linux_client: 
-test_results: 
+linux_client:
+test_results:
 updated_at: 2022-11-10
 vendor_url: https://www.paloaltonetworks.com/sase/globalprotect

--- a/_vendors/googleworkspace.yaml
+++ b/_vendors/googleworkspace.yaml
@@ -2,9 +2,9 @@
 name: Google Workspace
 ios_app:
 android_app: webview
-windows_client: 
-mac_client: 
-linux_client: 
-test_results: 
+windows_client:
+mac_client:
+linux_client:
+test_results:
 updated_at: 2022-11-09
 vendor_url: https://workspace.google.com

--- a/_vendors/jira_datacenter.yaml
+++ b/_vendors/jira_datacenter.yaml
@@ -3,8 +3,8 @@ name: Jira Datacenter
 ios_app: webview
 android_app: webview
 windows_client:
-mac_client: 
-linux_client: 
+mac_client:
+linux_client:
 test_results: https://jira.atlassian.com/browse/JRASERVER-70665
 updated_at: 2023-03-29
 vendor_url: https://www.atlassian.com/enterprise/data-center/jira

--- a/_vendors/lastpass.yaml
+++ b/_vendors/lastpass.yaml
@@ -1,10 +1,10 @@
 ---
-name: LastPass 
+name: LastPass
 ios_app: webview
-android_app: 
-windows_client: 
-mac_client: 
-linux_client: 
-test_results: 
+android_app:
+windows_client:
+mac_client:
+linux_client:
+test_results:
 updated_at: 2022-10-08
 vendor_url: https://www.lastpass.com/products/business

--- a/_vendors/lucidchart.yaml
+++ b/_vendors/lucidchart.yaml
@@ -1,10 +1,10 @@
 ---
 name: Lucidchart
 ios_app: webview
-android_app: 
-windows_client: 
-mac_client: 
-linux_client: 
-test_results: 
+android_app:
+windows_client:
+mac_client:
+linux_client:
+test_results:
 updated_at: 2022-11-08
 vendor_url: https://www.lucidchart.com/pages/

--- a/_vendors/microsoftoffice.yaml
+++ b/_vendors/microsoftoffice.yaml
@@ -1,10 +1,10 @@
 ---
 name: Microsoft Office
-ios_app: 
-android_app: 
+ios_app:
+android_app:
 windows_client: unclear
 mac_client: unclear
-linux_client: 
-test_results: 
+linux_client:
+test_results:
 updated_at: 2022-11-08
 vendor_url: https://www.microsoft.com/en-us/microsoft-365/business/compare-all-microsoft-365-business-products-b

--- a/_vendors/microsoftrdpclient.yaml
+++ b/_vendors/microsoftrdpclient.yaml
@@ -1,10 +1,10 @@
 ---
 name: Microsoft Remote Desktop client
-ios_app: 
-android_app: 
+ios_app:
+android_app:
 windows_client: true
 mac_client: false
-linux_client: 
-test_results: 
+linux_client:
+test_results:
 updated_at: 2023-09-06
 vendor_url: https://learn.microsoft.com/en-us/windows-server/remote/remote-desktop-services/clients/remote-desktop-clients

--- a/_vendors/microsoftvisualstudio.yaml
+++ b/_vendors/microsoftvisualstudio.yaml
@@ -1,10 +1,10 @@
 ---
 name: Microsoft Visual Studio
-ios_app: 
-android_app: 
+ios_app:
+android_app:
 windows_client: false
-mac_client: 
-linux_client: 
-test_results: 
+mac_client:
+linux_client:
+test_results:
 updated_at: 2023-09-06
 vendor_url: https://visualstudio.microsoft.com/vs/

--- a/_vendors/monday.com.yaml
+++ b/_vendors/monday.com.yaml
@@ -1,10 +1,10 @@
 ---
 name: Monday.com
 ios_app: unclear
-android_app: 
-windows_client: 
-mac_client: 
-linux_client: 
-test_results: 
+android_app:
+windows_client:
+mac_client:
+linux_client:
+test_results:
 updated_at: 2022-11-08
 vendor_url: https://monday.com/

--- a/_vendors/pulsesecure.yaml
+++ b/_vendors/pulsesecure.yaml
@@ -1,10 +1,10 @@
 ---
 name: Pulse Secure VPN
-ios_app: 
-android_app: 
+ios_app:
+android_app:
 windows_client: webview
 mac_client: webview
 linux_client: webview
-test_results: 
+test_results:
 updated_at: 2022-11-09
 vendor_url: https://www.pulsesecure.net/

--- a/_vendors/salesforce.yaml
+++ b/_vendors/salesforce.yaml
@@ -1,10 +1,10 @@
 ---
 name: Salesforce
 ios_app: unclear
-android_app: 
-windows_client: 
-mac_client: 
-linux_client: 
-test_results: 
+android_app:
+windows_client:
+mac_client:
+linux_client:
+test_results:
 updated_at: 2022-11-08
 vendor_url: https://www.salesforce.com/


### PR DESCRIPTION
I applied [yamllint](https://yamllint.readthedocs.io/en/stable/) but then decided it's mostly annoying and not very useful. Went with this Python script instead.

Originally looked at this because some folks weren't using `webview` or `unclear` but [ultimately the code for rendering is pretty cool with that](https://github.com/Authentication-Advocate/webauthn-wall-of-shame/blob/597a630ef65beff13d70326d8a3bc2ee256329ea/index.md?plain=1#L48-L63). A missing attribute however would be more of a problem, and I don't want anything merged if it lacks some specific attributes like `name`.